### PR TITLE
Added docker msql setup

### DIFF
--- a/containers/mysql/docker_compose_mysql.yml
+++ b/containers/mysql/docker_compose_mysql.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  mysql:
+    image: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: your_password
+    ports:
+      - "3306:3306"
+


### PR DESCRIPTION

### Description
Docker Compose .yml for setting up a MySQL database within a Docker container. The purpose of this setup is to provide an efficient and repeatable way to run a MySQL database for development and testing. The .yml file defines the necessary configurations for the MySQL container, including the image name, root password, and port mapping.

### Solution
The solution is to use Docker Compose, a tool for defining and running multi-container Docker applications. We have created a Docker Compose .yml file, docker_compose_mysql.yml, which specifies the MySQL service. 

### Testing
The Docker container builds successfuly .

What else did you do to test this?
I set up a MySQL database within a Docker container by running "docker-compose -f docker_compose_mysql.yml up -d" and connected to the database via MySQL Workbench