### PR TITLE
[ADAPTEDS-70] Video service

### DIFF
--- a/authorization/build.gradle
+++ b/authorization/build.gradle
@@ -36,6 +36,16 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // AWS S3 integration
+    // implementation 'org.springframework.cloud:spring-cloud-starter-aws'
+    // implementation 'org.springframework.cloud:spring-cloud-starter-aws-parameter-store-config'
+    // implementation(platform("software.amazon.awssdk:bom:2.21.1"))
+    // implementation("software.amazon.awssdk:s3")
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.0")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+    // implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
 }
 
 // when ./gradlew bootRun is executed first require that the application 

--- a/authorization/src/main/java/com/terabite/video/controller/VideoController.java
+++ b/authorization/src/main/java/com/terabite/video/controller/VideoController.java
@@ -25,22 +25,22 @@ public class VideoController {
         this.videoService = videoService;
     }
 
-    @PostMapping("/upload")
+    @PostMapping("")
     public ResponseEntity<?> uploadVideo(@RequestParam("video") MultipartFile video, @RequestParam("video_name") String videoName, @RequestParam("client") String client, HttpServletRequest request){
         return videoService.uploadVideo(video, videoName, client);
     }
 
-    @GetMapping("/download")
+    @GetMapping("")
     public ResponseEntity<S3Resource> getVideo(@RequestParam("video_name") String videoName, @RequestParam("client") String client, HttpServletRequest request){
         return videoService.downloadVideo(videoName, client);
     }
 
-    @DeleteMapping("/delete")
+    @DeleteMapping("")
     public ResponseEntity<?> deleteVideo(@RequestParam("video_name") String videoName, @RequestParam("client") String client, HttpServletRequest request){
         return videoService.deleteVideo(videoName, client);
     }
 
-    @DeleteMapping("/delete/all")
+    @DeleteMapping("/all")
     public ResponseEntity<?> deleteAllClientVideo(@RequestParam("client") String client, HttpServletRequest request){
         return videoService.deleteBucket(client);
     }

--- a/authorization/src/main/java/com/terabite/video/controller/VideoController.java
+++ b/authorization/src/main/java/com/terabite/video/controller/VideoController.java
@@ -1,0 +1,47 @@
+package com.terabite.video.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.terabite.video.service.VideoService;
+
+import io.awspring.cloud.s3.S3Resource;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.io.Resource;
+
+@RestController
+@RequestMapping("/v1/video")
+public class VideoController {
+    private final VideoService videoService;
+
+    public VideoController(VideoService videoService){
+        this.videoService = videoService;
+    }
+
+    @PostMapping("/upload")
+    public ResponseEntity<?> uploadVideo(@RequestParam("video") MultipartFile video, @RequestParam("video_name") String videoName, @RequestParam("client") String client, HttpServletRequest request){
+        return videoService.uploadVideo(video, videoName, client);
+    }
+
+    @GetMapping("/download")
+    public ResponseEntity<S3Resource> getVideo(@RequestParam("video_name") String videoName, @RequestParam("client") String client, HttpServletRequest request){
+        return videoService.downloadVideo(videoName, client);
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<?> deleteVideo(@RequestParam("video_name") String videoName, @RequestParam("client") String client, HttpServletRequest request){
+        return videoService.deleteVideo(videoName, client);
+    }
+
+    @DeleteMapping("/delete/all")
+    public ResponseEntity<?> deleteAllClientVideo(@RequestParam("client") String client, HttpServletRequest request){
+        return videoService.deleteBucket(client);
+    }
+}

--- a/authorization/src/main/java/com/terabite/video/service/VideoService.java
+++ b/authorization/src/main/java/com/terabite/video/service/VideoService.java
@@ -1,0 +1,124 @@
+package com.terabite.video.service;
+
+import java.io.IOError;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.util.Optional;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.awspring.cloud.s3.S3Resource;
+import io.awspring.cloud.s3.S3Template;
+import jakarta.validation.constraints.NotNull;
+import software.amazon.awssdk.core.Response;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import org.springframework.core.io.Resource;
+
+/**
+ * A service that processes video files.
+ * Coupled with the AWS S3 service for persistent storage of video files
+ * As such, each video is stored in an client-specific bucket, and each video has an video name unique to said bucket
+ * Ensure that the env vars AWS_SECRET_ACCESS_KEY && AWS_ACCESS_KEY_ID are set
+ */
+@Configuration
+@SuppressWarnings("null")
+public class VideoService {
+    private S3Template s3Template;
+
+    public VideoService(S3Template s3Template){
+        this.s3Template = s3Template;
+    }
+    
+    public ResponseEntity<?> uploadVideo(MultipartFile file, String videoName, String clientBucket){
+        if(!checkFileType(file.getResource(), file.getContentType() ) ) return new ResponseEntity<>(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        ensureClientBucketExists(clientBucket);
+        try(InputStream stream = file.getInputStream() ) {
+            uploadFile(clientBucket, videoName, stream);            
+            return new ResponseEntity<>(HttpStatus.ACCEPTED); 
+        }
+        catch(IOException e){
+            return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
+        }
+    }
+
+    public ResponseEntity<S3Resource> downloadVideo(String videoName, String clientBucket){
+        if(!checkIfClientBucketExist(clientBucket) ) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        if(!checkIfFileExists(clientBucket, videoName) ) return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(downloadFile(clientBucket, videoName), HttpStatus.OK);
+    }
+
+    public ResponseEntity<?> deleteVideo(String videoName, String clientBucket) {
+        if(!checkIfClientBucketExist(clientBucket) ) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        if(!checkIfFileExists(clientBucket, videoName) ) return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        deleteFile(clientBucket, videoName);
+        return new ResponseEntity<>(HttpStatus.OK);
+
+    }   
+
+    public ResponseEntity<?> deleteBucket(String clientBucket){
+        if(checkIfClientBucketExist(clientBucket)) {
+            s3Template.deleteBucket(clientBucket);
+            return new ResponseEntity<>(HttpStatus.OK);
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+    
+    // ***********************************************************
+    
+    /**
+     * Checks if the given file is in an acceptable video format
+     * @param resource the resource to check
+     * @param fileType the MIME type, if known
+     * @return true if acceptable, false otherwise
+     */
+    private boolean checkFileType(Resource resource, Optional<String> fileType){
+        String content = fileType.orElseGet(() -> "unknown");
+        return content.contains("video");
+
+        // TODO check resource for file type by interrogating file contents, as opposed to just using the MIME
+        // This is for security reasons, as the MIME type is self-reported, and as such, can be faked
+    }
+
+    /**
+     * Overloaded Method
+     * @param resource
+     * @param fileType
+     * @return
+     */
+    private boolean checkFileType(Resource resource, String fileType){
+        return checkFileType(resource, Optional.ofNullable(fileType) );
+    }
+
+    private boolean checkIfClientBucketExist(String bucket){
+        return s3Template.bucketExists(bucket);
+    }
+
+    private void ensureClientBucketExists(String bucket){
+        if(checkIfClientBucketExist(bucket) ) return;
+        else s3Template.createBucket(bucket);
+    }
+
+    private boolean checkIfFileExists(String bucket, String fileName){
+        return s3Template.objectExists(bucket, fileName);
+    }
+
+    private void uploadFile(String bucket, String fileName, InputStream file){
+        s3Template.upload(bucket, fileName, file);
+    }
+
+    private S3Resource downloadFile(String bucket, String fileName) {
+        return s3Template.download(bucket, fileName);
+    }
+
+    private void deleteFile(String bucket, String file){
+        s3Template.deleteObject(bucket, file);
+    }
+}

--- a/authorization/src/main/resources/application.properties
+++ b/authorization/src/main/resources/application.properties
@@ -12,3 +12,15 @@ spring.mail.username=${ADAPTED_STRENGTH_EMAIL}
 spring.mail.password=${ADAPTED_STRENGTH_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+spring.servlet.multipart.max-file-size=1000KB
+spring.servlet.multipart.max-request-size=1000KB
+spring.servlet.multipart.enabled=true
+
+spring.cloud.aws.s3.region=
+
+# cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
+# cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
+
+# cloud.aws.region.auto
+# cloud.aws.region.static: 


### PR DESCRIPTION

### Description
Store and retrieve videos.
Uses env vars `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` for auth with aws- make sure those are set
`spring.cloud.aws.s3.region` in `application-properties` controls which region to use
`spring.servlet.multipart.max-file-size` controls the max file size

### Solution
Each client has their own S3 bucket for storing videos. Client also includes Alex in this case.
Specifically, the POSTing an video takes a multipart video as follows
```
"video" : the video file
"video_name": the name of the video
"client": the client bucket that the video is stored in
```
The GETing an video takes the following endpoint.
```
"video_name": the name of the video
"client": the client bucket that the video is stored in
```
### Limitations
There are 3 right now.
1. We don't check auth permissions on the endpoint
2. We don't check auth permissions for the video - the client should only be able to access whatever videos they themselves upload, and shared with them (ie Alex's videos)
3. We do rudimentary checking to ensure that the file uploaded is a video file. This needs to be more robust, i.e. actually check the file binary to ensure it meets the format of whatever video formats we support. This is a security issue - the MIME checking relies on the content-type, and as such, can be falsified by a malicious actor.

### Testing
Endpoint works. Amazon S3 testing still needs to be done.

What else did you do to test this?
