### PR TITLE
[ADAPTEDS-113] JWT Invalidation

### DIFF
--- a/authorization/build.gradle
+++ b/authorization/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     // JWT specific
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation("com.google.guava:guava:33.1.0-jre") // For time-based expiration map
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/authorization/src/main/java/com/terabite/GlobalConfiguration.java
+++ b/authorization/src/main/java/com/terabite/GlobalConfiguration.java
@@ -110,7 +110,7 @@ public class GlobalConfiguration {
 
 	@Bean
 	public JwtService jwtService(@Qualifier(BEAN_JWT_SECRET) final String jwtSecret) {
-		return new JwtService(jwtSecret);
+		return new JwtService(jwtSecret, 1000 * 60 * 60 * 24);
 	}
 
 	@Bean

--- a/authorization/src/main/java/com/terabite/authorization/config/JwtAuthFilter.java
+++ b/authorization/src/main/java/com/terabite/authorization/config/JwtAuthFilter.java
@@ -69,7 +69,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             Cache<String, Boolean> blacklist = jwtService.getTokenBlacklist();
             if (blacklist.getIfPresent(token.get()) != null) {
                 raiseException(request, response, token.get());
-                log.error("Expired token provided: " + token.get());
+                log.error("Blacklisted token provided: " + token.get());
                 return;
             }
         }

--- a/authorization/src/main/java/com/terabite/authorization/config/JwtAuthFilter.java
+++ b/authorization/src/main/java/com/terabite/authorization/config/JwtAuthFilter.java
@@ -3,6 +3,7 @@ package com.terabite.authorization.config;
 import java.io.IOException;
 import java.util.Optional;
 
+import com.google.common.cache.Cache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +23,6 @@ import com.terabite.GlobalConfiguration;
 import com.terabite.authorization.dto.ApiResponse;
 import com.terabite.authorization.service.JwtService;
 import com.terabite.authorization.service.LoginService;
-import com.terabite.common.model.LoginDetails;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -54,11 +54,22 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         Optional<String> email = Optional.empty();
 
+        // Token validity checks
         if (token.isPresent() && !token.get().isBlank() && !token.get().equals("null")){
+
+            // Email existence checks
             email = jwtService.extractUsername(token.get());
             if (email.isEmpty()) {
                 raiseException(request, response, token.get());
-                log.error("Invalid token provided");
+                log.error("Invalid token provided: ");
+                return;
+            }
+
+            // Token blacklist checks
+            Cache<String, Boolean> blacklist = jwtService.getTokenBlacklist();
+            if (blacklist.getIfPresent(token.get()) != null) {
+                raiseException(request, response, token.get());
+                log.error("Expired token provided: " + token.get());
                 return;
             }
         }

--- a/authorization/src/main/java/com/terabite/authorization/controller/AuthorizationController.java
+++ b/authorization/src/main/java/com/terabite/authorization/controller/AuthorizationController.java
@@ -124,6 +124,7 @@ public class AuthorizationController {
 
         // Invalidate token
         jwtService.invalidateToken(token);
+        log.info("Token blacklist size: " + jwtService.getTokenBlacklist().size());
 
 //        LoginDetails loginDetails = (LoginDetails) userDetails;
         // Token should be added to a blacklist until it expires

--- a/authorization/src/main/java/com/terabite/authorization/controller/AuthorizationController.java
+++ b/authorization/src/main/java/com/terabite/authorization/controller/AuthorizationController.java
@@ -108,15 +108,28 @@ public class AuthorizationController {
     }
 
     @PostMapping("/logout")
-    public Payload userLogoutPost(@AuthenticationPrincipal UserDetails userDetials, HttpServletResponse response,
+    public Payload userLogoutPost(@AuthenticationPrincipal UserDetails userDetails, HttpServletResponse response,
             HttpServletRequest request) {
+        // Get Authorization Header
+        String authorizationHeader = null;
+        try {
+            authorizationHeader = request.getHeader("Authorization");
+        } catch (Exception e) {
+            log.info("/logout - No Authorization Header Found: " + e.getMessage());
+            return Payload.of(PayloadType.MESSAGE, "/logout - No Authorization Header Found: " + e.getMessage());
+        }
 
-        LoginDetails loginDetails = (LoginDetails) userDetials;
+        // Get token after "Bearer: "
+        String token = authorizationHeader.substring(7);
+
+        // Invalidate token
+        jwtService.invalidateToken(token);
+
+//        LoginDetails loginDetails = (LoginDetails) userDetails;
         // Token should be added to a blacklist until it expires
         // This blacklist should be checked in the JwtAuthFilter
 
         return Payload.of(PayloadType.MESSAGE, "Logout successful");
-
     }
 
     @PostMapping("/forgot_password")
@@ -187,7 +200,7 @@ public class AuthorizationController {
      * TODO: Remove in prod. Fix by ADAPTEDS-114
      */
     @GetMapping("/open_page")
-    @PreAuthorize("hasAnyAuthority('ROLE_UNVERIFIED', 'ROLE_ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_UNVERIFIED', 'ROLE_ADMIN')")
     public ResponseEntity<?> openPage() {
         return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.toString(), "Reached open page"));
     }

--- a/authorization/src/main/java/com/terabite/authorization/service/JwtService.java
+++ b/authorization/src/main/java/com/terabite/authorization/service/JwtService.java
@@ -29,20 +29,20 @@ public class JwtService {
 
     private static Logger log = LoggerFactory.getLogger(JwtService.class);
     private final Key SECRET;
-    private final long expiration;
+    private long expiration = DEFAULT_JWT_EXPIRATION;
     // Cache type is always a key-value pair. Using placeholder boolean for now
-    private Cache<String, Boolean> tokenBlacklist = CacheBuilder.newBuilder()
-            .expireAfterWrite(DEFAULT_JWT_EXPIRATION, TimeUnit.MILLISECONDS)
-            .build();
-
-    public JwtService(@Qualifier(GlobalConfiguration.BEAN_JWT_SECRET) final String jwtSecret) {
-        this(jwtSecret, DEFAULT_JWT_EXPIRATION);
-    }
+    private Cache<String, Boolean> tokenBlacklist;
+//    public JwtService(@Qualifier(GlobalConfiguration.BEAN_JWT_SECRET) final String jwtSecret) {
+//        this(jwtSecret, DEFAULT_JWT_EXPIRATION);
+//    }
 
     public JwtService(@Qualifier(GlobalConfiguration.BEAN_JWT_SECRET) final String jwtSecret,
                       final long expiration) {
         this.SECRET = Keys.hmacShaKeyFor(jwtSecret.getBytes());
         this.expiration = expiration;
+        this.tokenBlacklist = CacheBuilder.newBuilder()
+                .expireAfterWrite(expiration, TimeUnit.MILLISECONDS)
+                .build();
     }
 
     public Cache<String, Boolean> getTokenBlacklist() {

--- a/authorization/src/test/java/com/terabite/authorization/service/JwtServiceTests.java
+++ b/authorization/src/test/java/com/terabite/authorization/service/JwtServiceTests.java
@@ -32,8 +32,8 @@ public class JwtServiceTests {
     @BeforeEach
     void setup() {
         jwtService = new JwtService(SECRET1, EXPIRATION);
-        System.out.println("Secret1: " + SECRET1);
-        System.out.println("Secret2: " + SECRET2);
+//        System.out.println("Secret1: " + SECRET1);
+//        System.out.println("Secret2: " + SECRET2);
 
 
     }
@@ -125,14 +125,14 @@ public class JwtServiceTests {
 
             // TODO: have a control for preventing spam token invalidation
             for (int i = 0; i < 5; i++) {
-                System.out.println(jwtService.getTokenBlacklist().asMap());
+//                System.out.println(jwtService.getTokenBlacklist().asMap());
                 String token = jwtService.generateToken(loginDetails);
 
                 // Token is invalid, put in blacklist
                 jwtService.invalidateToken(token);
             }
 
-            // Value should be 1, despite 5 tokens being invalidated.
+            // Value should be 0, despite 5 tokens being invalidated.
             // This is because the blacklist internally "cleans up" after every modifying action
             // This means that the added tokens are immediately evicted after being added
             assertEquals(0, jwtService.getTokenBlacklist().size());

--- a/authorization/src/test/java/com/terabite/authorization/service/JwtServiceTests.java
+++ b/authorization/src/test/java/com/terabite/authorization/service/JwtServiceTests.java
@@ -1,12 +1,10 @@
 package com.terabite.authorization.service;
 
-import com.terabite.authorization.log.JwtValidationException;
-import com.terabite.authorization.service.JwtService;
-
+import com.terabite.common.model.LoginDetails;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,11 +28,14 @@ public class JwtServiceTests {
     private static final long EXPIRATION = 1000 * 60 * 60 * 24;
     private JwtService jwtService;
 
+
     @BeforeEach
     void setup() {
         jwtService = new JwtService(SECRET1, EXPIRATION);
         System.out.println("Secret1: " + SECRET1);
         System.out.println("Secret2: " + SECRET2);
+
+
     }
 
     @Test
@@ -85,8 +86,56 @@ public class JwtServiceTests {
         // New jwtService means a new secret. Tokens generated with old secret are
         // always invalid
         jwtService = null;
-        jwtService = new JwtService(SECRET2);
+        jwtService = new JwtService(SECRET2, EXPIRATION);
         assertFalse(jwtService.validateToken(token, userDetails));
     }
 
+    @Nested
+    class testTokenInvalidation {
+        LoginDetails loginDetails;
+
+        @BeforeEach
+        void setup() {
+            loginDetails = mock(LoginDetails.class);
+            when(loginDetails.getUsername()).thenReturn("testUser");
+            when(loginDetails.getRoles()).thenReturn(null);
+        }
+
+        @Test
+        void testInvalidateToken() {
+            jwtService = new JwtService(SECRET1, EXPIRATION);
+            String token = jwtService.generateToken(loginDetails);
+            boolean valid = jwtService.validateToken(token, loginDetails);
+
+            // Token is valid, and nothing is in the blacklist
+            assertTrue(valid);
+            assertEquals(0, jwtService.getTokenBlacklist().size());
+
+            jwtService.invalidateToken(token);
+//            jwtService.getTokenBlacklist().put(token, true);
+//            System.out.println(jwtService.getTokenBlacklist().asMap());
+
+            // Token is now invalid, and is in the blacklist
+            assertEquals(1, jwtService.getTokenBlacklist().size());
+        }
+
+        @Test
+        void testTokenBlacklistEviction() {
+            jwtService = new JwtService(SECRET1, 0);
+
+            // TODO: have a control for preventing spam token invalidation
+            for (int i = 0; i < 5; i++) {
+                System.out.println(jwtService.getTokenBlacklist().asMap());
+                String token = jwtService.generateToken(loginDetails);
+
+                // Token is invalid, put in blacklist
+                jwtService.invalidateToken(token);
+            }
+
+            // Value should be 1, despite 5 tokens being invalidated.
+            // This is because the blacklist internally "cleans up" after every modifying action
+            // This means that the added tokens are immediately evicted after being added
+            assertEquals(0, jwtService.getTokenBlacklist().size());
+        }
+    }
 }


### PR DESCRIPTION
### Description
Current JWT implementation lacks a mechanism for invalidating JWTS. This PR adds uses a token blacklist for invalidating incoming JWTs.

### Solution
I decided to go with a blacklist approach, as it it only requires modifying the backend. 
* This involves storing tokens we want to invalidate and checking all incoming requests against this blacklist

Resources for alternate strategies.
* https://stackoverflow.com/search?q=%23jjwt+invalidation&s=f3102e09-53ee-4320-986d-c7bb9c57701e
* https://stackoverflow.com/questions/21978658/invalidating-json-web-tokens
* https://stackoverflow.com/questions/51272360/can-jjwt-invalidate-tokens-on-the-server-side

The blacklist is stored in memory as a [Guava cache](https://github.com/google/guava/wiki/CachesExplained) 
* The blacklist is stored in memory because of performance reasons. Every incoming request is checked against the blacklist, and this is the most performant storage location I could think of
* I'm using a Guava cache as it's a data structure that has built-in expiration-based eviction. There are other choices such as [Caffeine](https://github.com/ben-manes/caffeine/wiki/Eviction) or Redis/Memcached that offer similar functionality

Concerns
* However, all these data structures only support a single expiration-time for eviction - there is some memory inefficiency
    * This means that no matter the expiration date on a JWT, they will all be blacklisted for the same amount of time
        * Take an expiration time of 6 hours for example. A token that is 5 hours old being invalidated means that it will still be blacklisted for the full 6 hours. This is 5 more hours than it ideally should be, as the token itself is naturally invalidated when it expires.
    * I decided not to create a custom data structure, as I'm not confident with how web servers and spring boot handles concurrent access for a data structure. If the efficiency is needed, we'll have to do this in the future

### Testing
Does the project build? Yes

What else did you do to test this? Unit testing, manual insomnia testing.
* Insomnia testing validated that invalidation disables a token
* Unit testing validated that tokens leave the blacklist after a set expiration time

[adapteds-113_jwt_invalidation.json](https://github.com/kyperbelt/adapted-strength/files/14813609/adapteds-113_jwt_invalidation.json)
